### PR TITLE
Add platform agnostic i18n interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/canonical/x-go
+
+go 1.13
+
+require (
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package i18n provides an implementation agnostic API to be used in
+// both library packages and application packages importing this library.
+// The application has the option to:
+//
+// 1. Initialise this package by implementing the i18n interface
+// 2. Leave the package uninitialised, disabling translation
+//
+// Warning:
+//
+// None of the i18n functionality may be used during early
+// initialisation code such as when defining a package 'const', 'var'
+// or 'init()'. This will prevent the application initialising
+// the i18n interface before it gets used in packages, and will
+// result in translation being disabled until the initialisation
+// setup is complete.
+
+package i18n
+
+// The following public i18n variables (function pointers) defines the
+// internationalisation marker API available. An implementation specific
+// version can be provided by the application or alternatively if left
+// unmodified the default functions will by used (translation disabled).
+var (
+	G  = GDefault
+	NG = NGDefault
+)
+
+// GDefault is the fallback implementation. This will simply return
+// the provided string untranslated.
+func GDefault(msgid string) string {
+	return msgid
+}
+
+// NGDefault is the fallback implementation. This will simply return
+// the provided singular or plural string (depending on 'n')
+// untranslated.
+func NGDefault(msgid string, msgidPlural string, n int) string {
+	if n == 1 {
+		// Singular
+		return msgid
+	} else {
+		// Plural
+		return msgidPlural
+	}
+}

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -35,7 +35,7 @@
 
 package i18n
 
-// The following public i18n variables (function pointers) defines the
+// The following public i18n function variables define the
 // internationalisation marker API available. An implementation specific
 // version can be provided by the application or alternatively if left
 // unmodified the default functions will by used (translation disabled).
@@ -57,8 +57,8 @@ func NGDefault(msgid string, msgidPlural string, n int) string {
 	if n == 1 {
 		// Singular
 		return msgid
-	} else {
-		// Plural
-		return msgidPlural
 	}
+
+	// Plural
+	return msgidPlural
 }

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package i18n_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/x-go/i18n"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type i18nSuite struct{}
+
+var _ = check.Suite(&i18nSuite{})
+
+func (ts *i18nSuite) TestDefaults(c *check.C) {
+	var call, callDefault reflect.Value
+
+	// i18n.G
+	call = reflect.ValueOf(i18n.G)
+	callDefault = reflect.ValueOf(i18n.GDefault)
+	c.Check(call.Pointer(), check.Equals, callDefault.Pointer(), check.Commentf("expected i18n.G == i18n.GDefault"))
+	c.Check(i18n.G("Hello"), check.Equals, "Hello", check.Commentf("expected output unchanged"))
+
+	// i18n.NG
+	call = reflect.ValueOf(i18n.NG)
+	callDefault = reflect.ValueOf(i18n.NGDefault)
+	c.Check(call.Pointer(), check.Equals, callDefault.Pointer(), check.Commentf("expected i18n.NG == i18n.NGDefault"))
+	c.Check(i18n.NG("Hello", "Hellos", 0), check.Equals, "Hellos", check.Commentf("expected plural form"))
+	c.Check(i18n.NG("Hello", "Hellos", 1), check.Equals, "Hello", check.Commentf("expected singular form"))
+	c.Check(i18n.NG("Hello", "Hellos", 2), check.Equals, "Hellos", check.Commentf("expected plural form"))
+}
+
+func (ts *i18nSuite) TestOverrides(c *check.C) {
+	i18n.G = func(msgid string) string { return "something" }
+	i18n.NG = func(msgid, msgid2 string, n int) string { return fmt.Sprintf("%s%d", "something", n) }
+
+	// i18n.G
+	c.Check(i18n.G("Hello"), check.Equals, "something", check.Commentf("expected translated output"))
+
+	// i18n.NG
+	c.Check(i18n.NG("Hello", "Hellos", 0), check.Equals, "something0", check.Commentf("expected translated output"))
+}

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -21,7 +21,6 @@ package i18n_test
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -36,18 +35,10 @@ type i18nSuite struct{}
 var _ = check.Suite(&i18nSuite{})
 
 func (ts *i18nSuite) TestDefaults(c *check.C) {
-	var call, callDefault reflect.Value
-
 	// i18n.G
-	call = reflect.ValueOf(i18n.G)
-	callDefault = reflect.ValueOf(i18n.GDefault)
-	c.Check(call.Pointer(), check.Equals, callDefault.Pointer(), check.Commentf("expected i18n.G == i18n.GDefault"))
 	c.Check(i18n.G("Hello"), check.Equals, "Hello", check.Commentf("expected output unchanged"))
 
 	// i18n.NG
-	call = reflect.ValueOf(i18n.NG)
-	callDefault = reflect.ValueOf(i18n.NGDefault)
-	c.Check(call.Pointer(), check.Equals, callDefault.Pointer(), check.Commentf("expected i18n.NG == i18n.NGDefault"))
 	c.Check(i18n.NG("Hello", "Hellos", 0), check.Equals, "Hellos", check.Commentf("expected plural form"))
 	c.Check(i18n.NG("Hello", "Hellos", 1), check.Equals, "Hello", check.Commentf("expected singular form"))
 	c.Check(i18n.NG("Hello", "Hellos", 2), check.Equals, "Hellos", check.Commentf("expected plural form"))
@@ -56,6 +47,10 @@ func (ts *i18nSuite) TestDefaults(c *check.C) {
 func (ts *i18nSuite) TestOverrides(c *check.C) {
 	i18n.G = func(msgid string) string { return "something" }
 	i18n.NG = func(msgid, msgid2 string, n int) string { return fmt.Sprintf("%s%d", "something", n) }
+	defer func() {
+		i18n.G = i18n.GDefault
+		i18n.NG = i18n.NGDefault
+	}()
 
 	// i18n.G
 	c.Check(i18n.G("Hello"), check.Equals, "something", check.Commentf("expected translated output"))

--- a/strutil/intersection_test.go
+++ b/strutil/intersection_test.go
@@ -22,7 +22,7 @@ package strutil_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type intersectionSuite struct{}

--- a/strutil/limbuffer_test.go
+++ b/strutil/limbuffer_test.go
@@ -22,7 +22,7 @@ package strutil_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type limitedBufferSuite struct{}

--- a/strutil/map_test.go
+++ b/strutil/map_test.go
@@ -23,7 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type orderedMapSuite struct{}

--- a/strutil/matchcounter_benchmark_test.go
+++ b/strutil/matchcounter_benchmark_test.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 func benchmarkMatchCounter(b *testing.B, wrx *regexp.Regexp, wn int) {

--- a/strutil/matchcounter_test.go
+++ b/strutil/matchcounter_test.go
@@ -24,7 +24,7 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type mcSuite struct{}

--- a/strutil/pathiter_test.go
+++ b/strutil/pathiter_test.go
@@ -22,7 +22,7 @@ package strutil_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type pathIterSuite struct{}

--- a/strutil/quantity/example_test.go
+++ b/strutil/quantity/example_test.go
@@ -27,7 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil/quantity"
+	"github.com/canonical/x-go/strutil/quantity"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/strutil/quantity/quantity.go
+++ b/strutil/quantity/quantity.go
@@ -23,8 +23,34 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/snapcore/snapd/i18n"
+	"github.com/canonical/x-go/i18n"
 )
+
+// Common package strings with translation support
+//
+// Note: This may not be converted as part of global 'const' or 'var'
+// variables, and also not inside 'init()'. The i18n implementation
+// is only available after early initialisation.
+
+func secs() rune {
+	return []rune(i18n.G("s"))[0]
+}
+
+func mins() rune {
+	return []rune(i18n.G("m"))[0]
+}
+
+func hours() rune {
+	return []rune(i18n.G("h"))[0]
+}
+
+func days() rune {
+	return []rune(i18n.G("d"))[0]
+}
+
+func years() rune {
+	return []rune(i18n.G("y"))[0]
+}
 
 // these are taken from github.com/chipaca/quantity with permission :-)
 
@@ -97,27 +123,13 @@ func divmod(a, b float64) (q, r float64) {
 	return q, a - q*b
 }
 
-var (
-	// TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
-	//    (I fully expect this to always be "s", given it's a SI unit)
-	secs = i18n.G("s")
-	// TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
-	mins = i18n.G("m")
-	// TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
-	hours = i18n.G("h")
-	// TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
-	days = i18n.G("d")
-	// TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
-	years = i18n.G("y")
-)
-
 // dt is seconds (as in the output of time.Now().Seconds())
 func FormatDuration(dt float64) string {
 	if dt < 60 {
 		if dt >= 9.995 {
-			return fmt.Sprintf("%.1f%s", dt, secs)
+			return fmt.Sprintf("%.1f%c", dt, secs())
 		} else if dt >= .9995 {
-			return fmt.Sprintf("%.2f%s", dt, secs)
+			return fmt.Sprintf("%.2f%c", dt, secs())
 		}
 
 		var prefix rune
@@ -129,68 +141,68 @@ func FormatDuration(dt float64) string {
 		}
 
 		if dt > 9.5 {
-			return fmt.Sprintf("%3.f%c%s", dt, prefix, secs)
+			return fmt.Sprintf("%3.f%c%c", dt, prefix, secs())
 		}
 
-		return fmt.Sprintf("%.1f%c%s", dt, prefix, secs)
+		return fmt.Sprintf("%.1f%c%c", dt, prefix, secs())
 	}
 
 	if dt < 600 {
 		m, s := divmod(dt, 60)
-		return fmt.Sprintf("%.f%s%02.f%s", m, mins, s, secs)
+		return fmt.Sprintf("%.f%c%02.f%c", m, mins(), s, secs())
 	}
 
 	dt /= 60 // dt now minutes
 
 	if dt < 99.95 {
-		return fmt.Sprintf("%3.1f%s", dt, mins)
+		return fmt.Sprintf("%3.1f%c", dt, mins())
 	}
 
 	if dt < 10*60 {
 		h, m := divmod(dt, 60)
-		return fmt.Sprintf("%.f%s%02.f%s", h, hours, m, mins)
+		return fmt.Sprintf("%.f%c%02.f%c", h, hours(), m, mins())
 	}
 
 	if dt < 24*60 {
 		if h, m := divmod(dt, 60); m < 10 {
-			return fmt.Sprintf("%.f%s%1.f%s", h, hours, m, mins)
+			return fmt.Sprintf("%.f%c%1.f%c", h, hours(), m, mins())
 		}
 
-		return fmt.Sprintf("%3.1f%s", dt/60, hours)
+		return fmt.Sprintf("%3.1f%c", dt/60, hours())
 	}
 
 	dt /= 60 // dt now hours
 
 	if dt < 10*24 {
 		d, h := divmod(dt, 24)
-		return fmt.Sprintf("%.f%s%02.f%s", d, days, h, hours)
+		return fmt.Sprintf("%.f%c%02.f%c", d, days(), h, hours())
 	}
 
 	if dt < 99.95*24 {
 		if d, h := divmod(dt, 24); h < 10 {
-			return fmt.Sprintf("%.f%s%.f%s", d, days, h, hours)
+			return fmt.Sprintf("%.f%c%.f%c", d, days(), h, hours())
 		}
-		return fmt.Sprintf("%4.1f%s", dt/24, days)
+		return fmt.Sprintf("%4.1f%c", dt/24, days())
 	}
 
 	dt /= 24 // dt now days
 
 	if dt < 2*period {
-		return fmt.Sprintf("%4.0f%s", dt, days)
+		return fmt.Sprintf("%4.0f%c", dt, days())
 	}
 
 	dt /= period // dt now years
 
 	if dt < 9.995 {
-		return fmt.Sprintf("%4.2f%s", dt, years)
+		return fmt.Sprintf("%4.2f%c", dt, years())
 	}
 
 	if dt < 99.95 {
-		return fmt.Sprintf("%4.1f%s", dt, years)
+		return fmt.Sprintf("%4.1f%c", dt, years())
 	}
 
 	if dt < 999.5 {
-		return fmt.Sprintf("%4.f%s", dt, years)
+		return fmt.Sprintf("%4.f%c", dt, years())
 	}
 
 	if dt > math.MaxUint64 || uint64(dt) == 0 {
@@ -198,5 +210,5 @@ func FormatDuration(dt float64) string {
 		return "ages!"
 	}
 
-	return FormatAmount(uint64(dt), 4) + years
+	return FormatAmount(uint64(dt), 4) + string(years())
 }

--- a/strutil/quantity/quantity.go
+++ b/strutil/quantity/quantity.go
@@ -32,24 +32,24 @@ import (
 // variables, and also not inside 'init()'. The i18n implementation
 // is only available after early initialisation.
 
-func secs() rune {
-	return []rune(i18n.G("s"))[0]
+func secs() string {
+	return i18n.G("s")
 }
 
-func mins() rune {
-	return []rune(i18n.G("m"))[0]
+func mins() string {
+	return i18n.G("m")
 }
 
-func hours() rune {
-	return []rune(i18n.G("h"))[0]
+func hours() string {
+	return i18n.G("h")
 }
 
-func days() rune {
-	return []rune(i18n.G("d"))[0]
+func days() string {
+	return i18n.G("d")
 }
 
-func years() rune {
-	return []rune(i18n.G("y"))[0]
+func years() string {
+	return i18n.G("y")
 }
 
 // these are taken from github.com/chipaca/quantity with permission :-)
@@ -127,9 +127,9 @@ func divmod(a, b float64) (q, r float64) {
 func FormatDuration(dt float64) string {
 	if dt < 60 {
 		if dt >= 9.995 {
-			return fmt.Sprintf("%.1f%c", dt, secs())
+			return fmt.Sprintf("%.1f%.1s", dt, secs())
 		} else if dt >= .9995 {
-			return fmt.Sprintf("%.2f%c", dt, secs())
+			return fmt.Sprintf("%.2f%.1s", dt, secs())
 		}
 
 		var prefix rune
@@ -141,68 +141,68 @@ func FormatDuration(dt float64) string {
 		}
 
 		if dt > 9.5 {
-			return fmt.Sprintf("%3.f%c%c", dt, prefix, secs())
+			return fmt.Sprintf("%3.f%c%.1s", dt, prefix, secs())
 		}
 
-		return fmt.Sprintf("%.1f%c%c", dt, prefix, secs())
+		return fmt.Sprintf("%.1f%c%.1s", dt, prefix, secs())
 	}
 
 	if dt < 600 {
 		m, s := divmod(dt, 60)
-		return fmt.Sprintf("%.f%c%02.f%c", m, mins(), s, secs())
+		return fmt.Sprintf("%.f%.1s%02.f%.1s", m, mins(), s, secs())
 	}
 
 	dt /= 60 // dt now minutes
 
 	if dt < 99.95 {
-		return fmt.Sprintf("%3.1f%c", dt, mins())
+		return fmt.Sprintf("%3.1f%.1s", dt, mins())
 	}
 
 	if dt < 10*60 {
 		h, m := divmod(dt, 60)
-		return fmt.Sprintf("%.f%c%02.f%c", h, hours(), m, mins())
+		return fmt.Sprintf("%.f%.1s%02.f%.1s", h, hours(), m, mins())
 	}
 
 	if dt < 24*60 {
 		if h, m := divmod(dt, 60); m < 10 {
-			return fmt.Sprintf("%.f%c%1.f%c", h, hours(), m, mins())
+			return fmt.Sprintf("%.f%.1s%1.f%.1s", h, hours(), m, mins())
 		}
 
-		return fmt.Sprintf("%3.1f%c", dt/60, hours())
+		return fmt.Sprintf("%3.1f%.1s", dt/60, hours())
 	}
 
 	dt /= 60 // dt now hours
 
 	if dt < 10*24 {
 		d, h := divmod(dt, 24)
-		return fmt.Sprintf("%.f%c%02.f%c", d, days(), h, hours())
+		return fmt.Sprintf("%.f%.1s%02.f%.1s", d, days(), h, hours())
 	}
 
 	if dt < 99.95*24 {
 		if d, h := divmod(dt, 24); h < 10 {
-			return fmt.Sprintf("%.f%c%.f%c", d, days(), h, hours())
+			return fmt.Sprintf("%.f%.1s%.f%.1s", d, days(), h, hours())
 		}
-		return fmt.Sprintf("%4.1f%c", dt/24, days())
+		return fmt.Sprintf("%4.1f%.1s", dt/24, days())
 	}
 
 	dt /= 24 // dt now days
 
 	if dt < 2*period {
-		return fmt.Sprintf("%4.0f%c", dt, days())
+		return fmt.Sprintf("%4.0f%.1s", dt, days())
 	}
 
 	dt /= period // dt now years
 
 	if dt < 9.995 {
-		return fmt.Sprintf("%4.2f%c", dt, years())
+		return fmt.Sprintf("%4.2f%.1s", dt, years())
 	}
 
 	if dt < 99.95 {
-		return fmt.Sprintf("%4.1f%c", dt, years())
+		return fmt.Sprintf("%4.1f%.1s", dt, years())
 	}
 
 	if dt < 999.5 {
-		return fmt.Sprintf("%4.f%c", dt, years())
+		return fmt.Sprintf("%4.f%.1s", dt, years())
 	}
 
 	if dt > math.MaxUint64 || uint64(dt) == 0 {
@@ -210,5 +210,5 @@ func FormatDuration(dt float64) string {
 		return "ages!"
 	}
 
-	return FormatAmount(uint64(dt), 4) + string(years())
+	return FormatAmount(uint64(dt), 4) + years()
 }

--- a/strutil/set_test.go
+++ b/strutil/set_test.go
@@ -22,7 +22,7 @@ package strutil_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type orderedSetSuite struct {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -27,7 +27,7 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 func Test(t *testing.T) { check.TestingT(t) }

--- a/strutil/version_benchmark_test.go
+++ b/strutil/version_benchmark_test.go
@@ -22,7 +22,7 @@ package strutil_test
 import (
 	"testing"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 var versions = []string{

--- a/strutil/version_test.go
+++ b/strutil/version_test.go
@@ -24,7 +24,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/strutil"
+	"github.com/canonical/x-go/strutil"
 )
 
 type VersionTestSuite struct{}


### PR DESCRIPTION
i18n support is built on top of github.com/snapcore/go-gettext.

The initialisation of i18n requires platform specific code, such
as the location of the language machine object (.mo) files.

Library packages and application packages wishing to provide locale
support are required to use some agreed i18n API (e.g. 'i18n.G' and
'i18n.NG') in order for the translation parser (xgettext) to find
the string markers.

This patch separates the required i18n API from the implementation
details. However, this i18n package must be provided with platform
specific versions of 'i18n.G' and 'i18n.NG' by overwriting the
package defaults during early application initialisation.

It is a supported use case not to overwrite the marker functions, in
which case the default implementation will simply pass the original
strings through, without translation.

Due to golang init ordering (see https://stackoverflow.com/a/49831018),
it would be impossible for the application to initialise the i18n
marker functions before packages make i18n calls, if these calls are
made inside package 'const', 'var' declarations or inside package
'init()' functions.

This means that calls to 'i18n.G', 'i18n.NG' and any other future marker
functions should only be made from a function or method.

Please see the snapd implementation for further details.