### PR TITLE
Fix commented code blocks for gofmt v1.19

### DIFF
--- a/strutil/pathiter.go
+++ b/strutil/pathiter.go
@@ -33,13 +33,13 @@ import (
 // openat calls.
 //
 // A simple example on how to use the iterator:
-// ```
-// iter:= NewPathIterator(path)
-// for iter.Next() {
-//    // Use iter.CurrentName() with openat(2) family of functions.
-//    // Use iter.CurrentPath() or iter.CurrentBase() for context.
-// }
-// ```
+//
+//	iter:= NewPathIterator(path)
+//
+//	for iter.Next() {
+//		// Use iter.CurrentName() with openat(2) family of functions.
+//		// Use iter.CurrentPath() or iter.CurrentBase() for context.
+//	}
 type PathIterator struct {
 	path        string
 	left, right int

--- a/strutil/shlex/shlex.go
+++ b/strutil/shlex/shlex.go
@@ -20,22 +20,21 @@ shell-style rules for quoting and commenting.
 
 The basic use case uses the default ASCII lexer to split a string into sub-strings:
 
-  shlex.Split("one \"two three\" four") -> []string{"one", "two three", "four"}
+	shlex.Split("one \"two three\" four") -> []string{"one", "two three", "four"}
 
 To process a stream of strings:
 
-  l := NewLexer(os.Stdin)
-  for ; token, err := l.Next(); err != nil {
-  	// process token
-  }
+	l := NewLexer(os.Stdin)
+	for ; token, err := l.Next(); err != nil {
+		// process token
+	}
 
 To access the raw token stream (which includes tokens for comments):
 
-  t := NewTokenizer(os.Stdin)
-  for ; token, err := t.Next(); err != nil {
-	// process token
-  }
-
+	t := NewTokenizer(os.Stdin)
+	for ; token, err := t.Next(); err != nil {
+		// process token
+	}
 */
 package shlex
 

--- a/strutil/version.go
+++ b/strutil/version.go
@@ -161,9 +161,10 @@ func compareSubversion(va, vb string) int {
 // VersionCompare compare two version strings that follow the debian
 // version policy and
 // Returns:
-//   -1 if a is smaller than b
-//    0 if a equals b
-//   +1 if a is bigger than b
+//
+//	-1 if a is smaller than b
+//	 0 if a equals b
+//	+1 if a is bigger than b
 func VersionCompare(va, vb string) (res int, err error) {
 	// FIXME: return err here instead
 	if !VersionIsValid(va) {


### PR DESCRIPTION
Gofmt v1.19 introduced some changes to how code within comment sections are detected and formatted.

See https://tip.golang.org/doc/go1.19 for gofmt changes and https://tip.golang.org/doc/comment for the section on codeblocks.