### PR TITLE
strutil: fix VersionCompare() to allow multiple - in the version

### DIFF
--- a/strutil/export_test.go
+++ b/strutil/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil
+
+var (
+	VersionIsValid = versionIsValid
+)

--- a/strutil/version.go
+++ b/strutil/version.go
@@ -101,10 +101,7 @@ func matchEpoch(a string) bool {
 // versionIsValid returns true if the given string is a valid
 // version number according to the debian policy
 func versionIsValid(a string) bool {
-	if matchEpoch(a) {
-		return false
-	}
-	return true
+	return !matchEpoch(a)
 }
 
 func nextFrag(s string) (frag, rest string, numeric bool) {

--- a/strutil/version.go
+++ b/strutil/version.go
@@ -98,9 +98,9 @@ func matchEpoch(a string) bool {
 	return i < len(a) && a[i] == ':'
 }
 
-// VersionIsValid returns true if the given string is a valid
+// versionIsValid returns true if the given string is a valid
 // version number according to the debian policy
-func VersionIsValid(a string) bool {
+func versionIsValid(a string) bool {
 	if matchEpoch(a) {
 		return false
 	}
@@ -154,10 +154,10 @@ func compareSubversion(va, vb string) int {
 //	+1 if a is bigger than b
 func VersionCompare(va, vb string) (res int, err error) {
 	// FIXME: return err here instead
-	if !VersionIsValid(va) {
+	if !versionIsValid(va) {
 		return 0, fmt.Errorf("invalid version %q", va)
 	}
-	if !VersionIsValid(vb) {
+	if !versionIsValid(vb) {
 		return 0, fmt.Errorf("invalid version %q", vb)
 	}
 

--- a/strutil/version.go
+++ b/strutil/version.go
@@ -98,26 +98,13 @@ func matchEpoch(a string) bool {
 	return i < len(a) && a[i] == ':'
 }
 
-func atMostOneDash(a string) bool {
-	seen := false
-	for i := 0; i < len(a); i++ {
-		if a[i] == '-' {
-			if seen {
-				return false
-			}
-			seen = true
-		}
-	}
-	return true
-}
-
 // VersionIsValid returns true if the given string is a valid
 // version number according to the debian policy
 func VersionIsValid(a string) bool {
 	if matchEpoch(a) {
 		return false
 	}
-	return atMostOneDash(a)
+	return true
 }
 
 func nextFrag(s string) (frag, rest string, numeric bool) {
@@ -175,12 +162,12 @@ func VersionCompare(va, vb string) (res int, err error) {
 	}
 
 	var sa, sb string
-	if ia := strings.IndexByte(va, '-'); ia < 0 {
+	if ia := strings.LastIndexByte(va, '-'); ia < 0 {
 		sa = "0"
 	} else {
 		va, sa = va[:ia], va[ia+1:]
 	}
-	if ib := strings.IndexByte(vb, '-'); ib < 0 {
+	if ib := strings.LastIndexByte(vb, '-'); ib < 0 {
 		sb = "0"
 	} else {
 		vb, sb = vb[:ib], vb[ib+1:]

--- a/strutil/version_test.go
+++ b/strutil/version_test.go
@@ -20,8 +20,6 @@
 package strutil_test
 
 import (
-	"fmt"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/x-go/strutil"
@@ -96,9 +94,8 @@ func (s *VersionTestSuite) TestVersionCompare(c *C) {
 		{"1.4+OOo3.0.0~", "1.4+OOo3.0.0-4", -1, nil}, // another tilde check
 		{"2.4.7-1", "2.4.7-z", -1, nil},              // revision comparing
 		{"1.002-1+b2", "1.00", 1, nil},               // whatever...
-
-		// broken
-		{"0--0", "0", 0, fmt.Errorf(`invalid version "0--0"`)},
+		{"12-20220319-1ubuntu1", "13-1-1", -1, nil},  // two "-" are legal
+		{"0--0", "0", 1, nil},                        // also legal (urgh)
 	} {
 		res, err := strutil.VersionCompare(t.A, t.B)
 		if t.err != nil {
@@ -118,7 +115,6 @@ func (s *VersionTestSuite) TestVersionInvalid(c *C) {
 		{"1:2", false},
 		{"12:34", false},
 		{"1234:", false},
-		{"1--1", false},
 		{"1.0", true},
 		{"1234", true},
 	} {


### PR DESCRIPTION
The current code in strutil.VersionCompare() is not fully
compatible with what a debian version allows. Specifically
the version number of libgcc-s1 in 22.04 is valid
(12-20220319-1ubuntu1) but it's rejected right now.

The debian policy [1] says:

The upstream_version may contain only alphanumerics[14] and the
characters . + - : (full stop, plus, hyphen, colon) and should
start with a digit. If there is no debian_revision then hyphens
are not allowed; if there is no epoch then colons are not allowed.
and python-apt/apt/dpkg are all happy with the version. Given that
we generally follow the debian policy for this we should fix this.

Thanks to Gustavo for pointing this out.

As a drive-by I also include a commit that un-exports "strutil.VersionIsValid()"
that is not used in our code. I can remove this commit if undesired.

If approved this should also be cherry-picked into https://github.com/canonical/x-go/

[1] https://www.debian.org/doc/debian-policy/ch-controlfields.html#version

Cherry-picked from https://github.com/snapcore/snapd/pull/12036