### PR TITLE
strutil: add UUID v4 generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/strutil/uuid.go
+++ b/strutil/uuid.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2014-2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package strutil
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// UUID returns a randomly generated v4 UUID using crypto random sources.
+func UUID() (string, error) {
+	var r [16]byte
+	_, err := rand.Read(r[:])
+	if err != nil {
+		return "", err
+	}
+	id := fmt.Sprintf("%x-%x-%x-%x-%x", r[:4], r[4:6], r[6:8], r[8:10], r[10:16])
+	return id, nil
+}

--- a/strutil/uuid_test.go
+++ b/strutil/uuid_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License UUID 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package strutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/x-go/strutil"
+)
+
+type UUIDTestSuite struct{}
+
+var _ = Suite(&UUIDTestSuite{})
+
+func (s *UUIDTestSuite) TestUUID(c *C) {
+	u, err := strutil.UUID()
+	c.Check(err, IsNil)
+	c.Check(u, HasLen, 36)
+	c.Check(u, Matches, `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	c.Check(u, Not(Equals), "00000000-0000-0000-0000-000000000000")
+	u2, err := strutil.UUID()
+	c.Check(err, IsNil)
+	c.Check(u2, Not(Equals), u)
+}


### PR DESCRIPTION
Add a v4 UUID generator function utilizing crypto random sources.

Originally provided by github.com/canonical/pebble, now relocated to x-go.