### PR TITLE
strutil: add a random string maker function

### DIFF
--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -22,12 +22,34 @@ package strutil
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 )
+
+func init() {
+	// golang does not init Seed() itself
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+const letters = "BCDFGHJKLMNPQRSTVWXYbcdfghjklmnpqrstvwxy0123456789"
+
+// MakeRandomString returns a random string of length length
+//
+// The vowels are omitted to avoid that words are created by pure
+// chance. Numbers are included.
+func MakeRandomString(length int) string {
+	out := ""
+	for i := 0; i < length; i++ {
+		out += string(letters[rand.Intn(len(letters))])
+	}
+
+	return out
+}
 
 // SizeToStr converts the given size in bytes to a readable string
 func SizeToStr(size int64) string {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -22,6 +22,7 @@ package strutil_test
 import (
 	"bytes"
 	"math"
+	"math/rand"
 	"sort"
 	"testing"
 
@@ -35,6 +36,17 @@ func Test(t *testing.T) { check.TestingT(t) }
 type strutilSuite struct{}
 
 var _ = check.Suite(&strutilSuite{})
+
+func (ts *strutilSuite) TestMakeRandomString(c *check.C) {
+	// for our tests
+	rand.Seed(1)
+
+	s1 := strutil.MakeRandomString(10)
+	c.Assert(s1, check.Equals, "pw7MpXh0JB")
+
+	s2 := strutil.MakeRandomString(5)
+	c.Assert(s2, check.Equals, "4PQyl")
+}
 
 func (*strutilSuite) TestQuoted(c *check.C) {
 	for _, t := range []struct {


### PR DESCRIPTION
Add a helper function that can generate a string of specified length, containing random characters.

Originally provided by github.com/canonical/pebble, now relocated to x-go.