### PR TITLE
randutil: add RandomKernelUUID() tests and tweaks

### DIFF
--- a/randutil/crypto.go
+++ b/randutil/crypto.go
@@ -52,10 +52,10 @@ func CryptoToken(nbytes int) (string, error) {
 // RandomKernelUUID will return a UUID from the kernel's procfs API at
 // /proc/sys/kernel/random/uuid. Only to be used in very specific uses, most
 // random code should use CryptoToken(Bytes) instead.
-func RandomKernelUUID() string {
+func RandomKernelUUID() (string, error) {
 	b, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
 	if err != nil {
-		panic("cannot read kernel generated uuid")
+		return "", fmt.Errorf("cannot access kernel generated uuid: %w", err)
 	}
-	return strings.TrimSpace(string(b))
+	return strings.TrimSpace(string(b)), nil
 }

--- a/randutil/crypto.go
+++ b/randutil/crypto.go
@@ -49,11 +49,14 @@ func CryptoToken(nbytes int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+// Allow mocking of the path through an exported reference.
+var kernelUUIDPath = "/proc/sys/kernel/random/uuid"
+
 // RandomKernelUUID will return a UUID from the kernel's procfs API at
 // /proc/sys/kernel/random/uuid. Only to be used in very specific uses, most
 // random code should use CryptoToken(Bytes) instead.
 func RandomKernelUUID() (string, error) {
-	b, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
+	b, err := ioutil.ReadFile(kernelUUIDPath)
 	if err != nil {
 		return "", fmt.Errorf("cannot access kernel generated uuid: %w", err)
 	}

--- a/randutil/crypto_test.go
+++ b/randutil/crypto_test.go
@@ -21,6 +21,9 @@ package randutil_test
 
 import (
 	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
@@ -44,4 +47,70 @@ func (s *cryptoRandutilSuite) TestCryptoToken(c *C) {
 	b, err := base64.RawURLEncoding.DecodeString(x)
 	c.Assert(err, IsNil)
 	c.Check(b, HasLen, 5)
+}
+
+var (
+	kernelTestUUID = "1031319a-b661-4c01-aafa-6def8a118944"
+)
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUIDNoFile(c *C) {
+	uuidPath := filepath.Join(c.MkDir(), "no-file")
+	defer randutil.MockKernelUUIDPath(uuidPath)()
+
+	value, err := randutil.RandomKernelUUID()
+	c.Check(value, Equals, "")
+	c.Check(err, ErrorMatches,
+		"cannot access kernel generated uuid:"+
+			".*no-file: no such file or directory")
+}
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUIDNoPerm(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("Permission tests will not work when user is root")
+	}
+
+	uuidPath := filepath.Join(c.MkDir(), "no-perm")
+	defer randutil.MockKernelUUIDPath(uuidPath)()
+
+	err := ioutil.WriteFile(uuidPath, []byte(kernelTestUUID), 0)
+	c.Assert(err, IsNil)
+
+	value, err := randutil.RandomKernelUUID()
+	c.Check(value, Equals, "")
+	c.Assert(err, ErrorMatches,
+		"cannot access kernel generated uuid:"+
+			".*no-perm: permission denied")
+}
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUID(c *C) {
+	for _, uuid := range []string{
+		kernelTestUUID,
+		" \t\n " + kernelTestUUID + " \n\t\r\n",
+	} {
+		// Create new path on each iteration because we cannot
+		// reuse previous path to read-only (0444) file.
+		uuidPath := filepath.Join(c.MkDir(), "uuid")
+		defer randutil.MockKernelUUIDPath(uuidPath)()
+
+		err := ioutil.WriteFile(uuidPath, []byte(uuid), 0444)
+		c.Assert(err, IsNil)
+
+		value, err := randutil.RandomKernelUUID()
+		c.Check(value, Equals, kernelTestUUID)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUIDReal(c *C) {
+	if _, err := os.Stat(randutil.KernelUUIDPath); err != nil {
+		c.Skip("Kernel UUID procfs file is not accessible in the current test environment")
+	}
+
+	value, err := randutil.RandomKernelUUID()
+	c.Check(value, Not(Equals), "")
+	// https://www.rfc-editor.org/rfc/rfc4122#section-3
+	// We are not testing the kernel here, so minimal check:
+	// UUID should be 36 bytes in length exactly.
+	c.Check(value, HasLen, 36)
+	c.Assert(err, IsNil)
 }

--- a/randutil/export_test.go
+++ b/randutil/export_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package randutil
+
+// Needed by TestRandomKernelUUIDReal() to check if access
+// to kernel path exist on test host.
+var KernelUUIDPath = kernelUUIDPath
+
+func MockKernelUUIDPath(newPath string) (restore func()) {
+	kernelUUIDPathDefault := kernelUUIDPath
+	kernelUUIDPath = newPath
+	return func() {
+		kernelUUIDPath = kernelUUIDPathDefault
+	}
+}


### PR DESCRIPTION
This patchset makes the following changes:

- Make RandomKernelUUID() return an error instead of internally raising a panic. This will allow application code depending on this library function to decide on the severity of failure instead. This is required by Pebble, where its previous local version of a UUID function returned an error.
- Add unit tests for RandomKernelUUID()