### PR TITLE
strutil/shlex: add Quote() and Join() for shell-escaped quoting

### DIFF
--- a/strutil/shlex/shlex.go
+++ b/strutil/shlex/shlex.go
@@ -414,3 +414,33 @@ func Split(s string) ([]string, error) {
 		subStrings = append(subStrings, word)
 	}
 }
+
+// Join returns a shell-escaped string version of the arguments in s.
+func Join(s []string) string {
+	quoted := make([]string, len(s))
+	for i, x := range s {
+		quoted[i] = Quote(x)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// Quote returns a shell-escaped version of the single argument s.
+func Quote(s string) string {
+	if s == "" {
+		return `''`
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case strings.IndexByte("_@%+=:,./-", c) >= 0:
+		default:
+			// The above cases are all the safe characters. If there are any
+			// other characters, quote the entire input.
+			return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+		}
+	}
+	return s
+}

--- a/strutil/shlex/shlex_test.go
+++ b/strutil/shlex/shlex_test.go
@@ -157,3 +157,105 @@ func TestNastyReader(t *testing.T) {
 		t.Errorf("unexpected error")
 	}
 }
+
+var quoteTests = []struct {
+	name     string
+	input    string
+	expected string
+}{{
+	name:     `empty`,
+	input:    ``,
+	expected: `''`,
+}, {
+	name:     `quote safe`,
+	input:    "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789" + "@%_-+=:,./",
+	expected: "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789" + "@%_-+=:,./",
+}, {
+	name:     `spaces`,
+	input:    `foo bar xyz`,
+	expected: `'foo bar xyz'`,
+}, {
+	name:     `double quotation`,
+	input:    `foo"bar`,
+	expected: `'foo"bar'`,
+}, {
+	name:     `backtick`,
+	input:    "foo`bar",
+	expected: "'foo`bar'",
+}, {
+	name:     `backslash`,
+	input:    `foo\bar`,
+	expected: `'foo\bar'`,
+}, {
+	name:     `unicode`,
+	input:    "foo\xe9bar",
+	expected: "'foo\xe9bar'",
+}, {
+	name:     `single quote with exclamation point`,
+	input:    `foo!'bar'`,
+	expected: `'foo!'"'"'bar'"'"''`,
+}, {
+	name:     `single quote with dollar`,
+	input:    `'foo$'bar`,
+	expected: `''"'"'foo$'"'"'bar'`,
+}}
+
+func TestQuote(t *testing.T) {
+	for _, test := range quoteTests {
+		t.Run(test.name, func(t *testing.T) {
+			quoted := Quote(test.input)
+			if quoted != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, quoted)
+			}
+		})
+	}
+}
+
+var joinTests = []struct {
+	name     string
+	input    []string
+	expected string
+}{{
+	name:     `space in first arg`,
+	input:    []string{`a `, `b`},
+	expected: `'a ' b`,
+}, {
+	name:     `space in last arg`,
+	input:    []string{`a`, ` b`},
+	expected: `a ' b'`,
+}, {
+	name:     `space as an arg`,
+	input:    []string{`a`, ` `, `b`},
+	expected: `a ' ' b`,
+}, {
+	name:     `empty arg`,
+	input:    []string{`a`, ``, `b`},
+	expected: `a '' b`,
+}, {
+	name:     `double quotes in arg`,
+	input:    []string{`"a`, `b"`},
+	expected: `'"a' 'b"'`,
+}, {
+	name:     `long args`,
+	input:    []string{`x y`, `/foo/bar`},
+	expected: `'x y' /foo/bar`,
+}, {
+	name:     `empty slice`,
+	input:    []string{},
+	expected: ``,
+}, {
+	name:     `nil slice`,
+	input:    nil,
+	expected: ``,
+}}
+
+func TestJoin(t *testing.T) {
+	for _, test := range joinTests {
+		t.Run(test.name, func(t *testing.T) {
+			joined := Join(test.input)
+			if joined != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, joined)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Inspired from Python shlex [0, 1], add Quote(string) to return a shell-escaped version of a string.
Add Join([]string) to join the shell-escaped version of the strings in slice.

References:
- [0] https://github.com/python/cpython/blob/fd155b91392c5bd238781bb11e040cf46c94725c/Lib/shlex.py#L323C31-L334
- [1] https://github.com/python/cpython/blob/fd155b91392c5bd238781bb11e040cf46c94725c/Lib/test/test_shlex.py#L327-L351