### PR TITLE
Realign Go versions with x-go dependent projects

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.19', '1.18', '1.13']
+        go: ['1.14', '1.18']
 
     name: run-checks-with-go-v${{ matrix.go }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/canonical/x-go
 
-go 1.13
+go 1.14
 
 require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/run-checks
+++ b/run-checks
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2145
-
 #----------------------------------------------------#
 # PRINTING ROUTINES                                  #
 #----------------------------------------------------#
@@ -15,19 +13,19 @@ print_newline() {
 }
 
 print_normal() {
-	echo -e "$P_RESET$@"
+	echo -e "$P_RESET$*"
 }
 
 print_red() {
-	echo -e "$P_RED$@$P_RESET"
+	echo -e "$P_RED$*$P_RESET"
 }
 
 print_green() {
-	echo -e "$P_GREEN$@$P_RESET"
+	echo -e "$P_GREEN$*$P_RESET"
 }
 
 print_special() {
-	echo -ne "$P_RESET$@"
+	echo -ne "$P_RESET$*"
 }
 
 #----------------------------------------------------#
@@ -144,18 +142,27 @@ run() {
         fi
 }
 
+# Install staticcheck from the correct source so that it
+# will compile and install for the Go version on the host.
+#
+# shellcheck disable=SC2317
+# Disable "command appears to be unreachable" warnings. This function
+# is indirectly called through run(), which confuses shellcheck.
+#
 install_staticcheck() {
-    pkg="honnef.co/go/tools/cmd/staticcheck"
-    # go1.18+ will no longer build/install packages. Here "go install"
-    # must be used but it will only fetch remote packages if the @latest
-    # (or similar syntax is used). Instead of checking the version we
-    # check if the "go install" help mentions this new feature.
-    if go help install | grep -q @latest; then
-	# Go v1.8+
-        go install "${pkg}"@latest
+    # We build from source to make this architecture independent.
+    # However, staticcheck releases are dependent on specific Go
+    # versions, so we cannot simply build the latest.
+    PKG="honnef.co/go/tools/cmd/staticcheck"
+    GO_VERSION="$(go version | cut -d' ' -f3 | cut -d'.' -f1-2 | sed 's/go//' | sed 's/\.//')"
+
+    # This list will be updated as x-go moves to later Go versions.
+    if [ "$GO_VERSION" -ge "118" ]; then
+        # Go v1.18
+        go install "${PKG}@2022.1.3"
     else
-	# Go v1.3
-        go get "${pkg}@2019.2.3"
+        # Go v1.14
+        go get "${PKG}@2021.1.2"
     fi
 }
 


### PR DESCRIPTION
As of today the minimum Go version for projects directly or indirectly dependant on x-go is as follows:

snapd:  Go v1.18 (tracking but not importing x-go)
chisel: Go v1.18 (not currently using x-go)
pebble: Go v1.14 (importing x-go)

- Update x-go to match the minimum Go version of Pebble (1.13 => 1.14)
- Update the gopkg.in/yaml.v2 package used by strutil to match Snapd (2.3.0 => 2.4.0)
- Change CI tests to Go v1.14 and Go v1.18
- Remove shellcheck disable SC2145 because the code has been improved to not trigger the warning.