### PR TITLE
strutil: add NumItems for singular vs plural display

### DIFF
--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -365,3 +365,12 @@ func WordWrapPadded(out io.Writer, text []rune, pad string, termWidth int) error
 	}
 	return WordWrap(out, text, indent, indent, termWidth)
 }
+
+// NumItems returns the string form of the number of items: the singular form
+// (eg: "1 item") if n is 1, otherwise the plural form (eg: "7 items").
+func NumItems(n int, singular, plural string) string {
+	if n == 1 {
+		return "1 " + singular
+	}
+	return strconv.Itoa(n) + " " + plural
+}

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -363,3 +363,24 @@ func (strutilSuite) TestWordWrapPadded(c *check.C) {
 		c.Check(buf.String(), check.Equals, t.output)
 	}
 }
+
+func (strutilSuite) TestNumItems(c *check.C) {
+	tests := []struct {
+		n        int
+		singular string
+		plural   string
+		output   string
+	}{
+		{0, "item", "items", "0 items"},
+		{1, "item", "items", "1 item"},
+		{2, "item", "items", "2 items"},
+		{42, "item", "items", "42 items"},
+		{1, "new car", "new cars", "1 new car"},
+		{42, "new car", "new cars", "42 new cars"},
+	}
+	for _, test := range tests {
+		c.Logf("%d %q %q -> %q", test.n, test.singular, test.plural, test.output)
+		output := strutil.NumItems(test.n, test.singular, test.plural)
+		c.Check(output, check.Equals, test.output)
+	}
+}


### PR DESCRIPTION
Thoughts?

This is a function that I've implemented at least once in Pebble already. It's one of those that's really simple to write, but annoying every time you have to:

```go
// Without:
if len(identities) == 1 {
	fmt.Fprintf(Stdout, "Removed 1 identity\n")
} else {
	fmt.Fprintf(Stdout, "Removed %d identities\n", len(identities))
}

// With:
fmt.Fprintf(Stdout, "Removed %s\n", strutil.NumItems(len(identities), "identity", "identities"))
```

I'm not sure about the name. I played with `Pluralize` but that's not right. Then I had `SingularPlural`, which is okay, but `NumItems` feels more like what it does. Could even do `strutil.Num` or even `strutil.N`.

Note that this is not internationalised (but none of Pebble is, for example). That would require something like gettext (ngettext). Note that nggettext uses the argument order `singular, plural, n`, but that felt more awkward.