### PR TITLE
chore: update minimum Go version to 1.18

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.18']
+        go: ['1.18']
 
     name: run-checks-with-go-v${{ matrix.go }}
 

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,8 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+require (
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.1.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/x-go
 
-go 1.14
+go 1.18
 
 require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/run-checks
+++ b/run-checks
@@ -161,8 +161,10 @@ install_staticcheck() {
         # Go v1.18
         go install "${PKG}@2022.1.3"
     else
-        # Go v1.14
-        go get "${PKG}@2021.1.2"
+        print_newline
+        print_red "Must use Go version >= 1.18"
+        print_newline
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Copying / contributing packages of interest to x-go is difficult since the baseline version of Go in the other projects has moved on from x-go's current version of 1.14. Let's reasonably raise the baseline so we can add some functionality. 

The current Go version for the primary projects of interest to x-go is as follows:

- Snapd (not using x-go yet): [1.18](https://github.com/canonical/snapd/blob/030cc8c2468e00c4f6e992035b1d217f0e44eee0/go.mod#L3)
- Chisel (not using x-go yet): [1.23.8](https://github.com/canonical/chisel/blob/680d53c125828bb83d44f0200bbbc132bc4ff1b9/go.mod#L3)
- Pebble (using x-go): [1.24.6](https://github.com/canonical/pebble/blob/b58ea3bf3755c50792154c2380a874d379601cc0/go.mod#L3)

The current Go version for other projects which import x-go is as follows:

- Concierge (using x-go): [1.24.4](https://github.com/canonical/concierge/blob/a0dda2dc0ec54373f16afac243ea716201878960/go.mod#L3)

The full list of Canonical projects which import x-go can be found here:  https://github.com/search?q=org%3Acanonical+path%3A**%2Fgo.mod+%22github.com%2Fcanonical%2Fx-go%22&type=code

Let's update x-go to match the minimum Go version of snapd (1.18). 