### PR TITLE
chore: update codecov to v5 and use token upload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           name: "Delta Report"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,3 +44,4 @@ jobs:
           fail_ci_if_error: true
           name: "Delta Report"
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fix codecov failures by using token-based upload and update version to v5.

Resolves: #21 