### PR TITLE
fix: nil check in KillProcessGroup, break in OrderedMap.Del, remove redundant filepath.Join in FakeCmd

### DIFF
--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -38,6 +38,9 @@ var (
 // If the command hasn't had Setpgid set in its SysProcAttr, you'll probably end
 // up killing yourself.
 func KillProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return fmt.Errorf("cannot kill process group: process not started")
+	}
 	pgid, err := syscallGetpgid(cmd.Process.Pid)
 	if err != nil {
 		return err

--- a/osutil/exec_test.go
+++ b/osutil/exec_test.go
@@ -105,6 +105,12 @@ func (s *execSuite) TestKillProcessGroupKillsProcessGroup(c *C) {
 	c.Check(pid, Equals, -ppid)
 }
 
+func (s *execSuite) TestKillProcessGroupNotStarted(c *C) {
+	cmd := exec.Command("sleep", "1m")
+	err := osutil.KillProcessGroup(cmd)
+	c.Assert(err, ErrorMatches, "cannot kill process group: process not started")
+}
+
 func (s *execSuite) TestKillProcessGroupShyOfInit(c *C) {
 	defer osutil.FakeSyscallGetpgid(func(int) (int, error) { return 1, nil })()
 

--- a/strutil/map.go
+++ b/strutil/map.go
@@ -66,6 +66,7 @@ func (o *OrderedMap) Del(key string) {
 			if k == key {
 				copy(o.keys[i:], o.keys[i+1:])
 				o.keys = o.keys[:len(o.keys)-1]
+				break
 			}
 		}
 	}

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -147,5 +147,5 @@ func (cmd *FakeCmd) BinDir() string {
 
 // Exe return the full path of the fake binary
 func (cmd *FakeCmd) Exe() string {
-	return filepath.Join(cmd.exeFile)
+	return cmd.exeFile
 }


### PR DESCRIPTION
Address minor issues found while doing sonar code analysis 

1. osutil/exec.go;  pointer dereference in `KillProcessGroup`  
   The function accessed `cmd.Process.Pid` without checking if `cmd.Process` was nil.  https://github.com/canonical/x-go/commit/3876c0a9eb86ca959a4b736cd58923cf03e904c3

2. strutil/map.go; missing break in `OrderedMap.Del`  
   After removing the key from the `keys` slice, the loop continued iterating over stale or shifted data.  https://github.com/canonical/x-go/commit/253bcb59673edb5317f65471a5ea86aaeec04e31

3. testutil/exec.go; redundant `filepath.Join` with single argument  
   `filepath.Join(cmd.exeFile)` is equivalent to `filepath.Clean(cmd.exeFile)`, which is unnecessary here.  
